### PR TITLE
Improve behavior of `jaws deploy` when updating previously deployed lambdas.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,5 @@ site/public/libs
 site/node_modules
 lib/node_modules
 cli/node_modules
-api/**/node_modules
+api/**/**/node_modules
 


### PR DESCRIPTION
In its current implementation, `jaws deploy` checks to see if the lambda function exists and, if it does not, it creates a new function, if it does, it deletes the existing function and creates a new function.

In the case where the function exists, this pattern decouples the previously deployed function from its associated API endpoints, rendering the API endpoint broken. I have not yet found a way to re-couple the function and the endpoint resource method without deleting the method and starting over.

By replacing the deleteFunction/createFunction pattern with one that uses aws-sdk's updateFunctionCode/updateFunctionConfiguration, the code and configuration are updated without deleting the deployed references and the API endpoint remains intact.

Additionally, this PR includes a small fix to .gitignore which brings it into conformance with the prescribed API directory structure, e.g. /api/users/list which places the node_modules directory one level deeper than the existing .gitignore supports.