### PR TITLE
Allow npm warning when cli package installed locally

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -19,6 +19,7 @@
         "amazon web services",
         "dynamodb"
     ],
+    "preferGlobal": true,
     "main": "lib/main.js",
     "bin": {
         "jaws": "./bin/jaws"


### PR DESCRIPTION
All CLI packages should have the `preferGlobal` property set to true in their `package.json`, so npm will warn people to install it with the -g flag.