### PR TITLE
add projecttalk link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 JAWS: The Server-less Framework
 =================================
 
+[![ProjectTalk](http://www.projecttalk.io/images/gh_badge-3e578a9f437f841de7446bab9a49d103.svg?vsn=d)] (http://www.projecttalk.io/boards/jaws-stack%2FJAWS?utm_campaign=gh-badge&utm_medium=badge&utm_source=github) 
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/jaws-stack/JAWS?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 This stack uses new tools from Amazon Web Services to completely redefine how to build massively scalable (and cheap) web applications.


### PR DESCRIPTION
hey,

this adds a badge to the JAWS messageboard on projecttalk.io.

i think it's a nice addition to the current "support channels", as gitter needs synchronous  communication (people aren't always online at the same time) and github issues aren't really meant for users helping each others either.