### PR TITLE
fix(new) setAwsAdminCreds

### DIFF
--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -157,7 +157,7 @@ module.exports = function(JAWS) {
               JawsError.errorCodes.MISSING_AWS_CREDS));
         }
 
-        JAWS._utils.setAwsAdminCreds('default');
+        JAWS._utils.setAwsAdminCreds('default', answers.awsAdminKeyId, answers.awsAdminSecretKey);
         project.creds = new AWS.SharedIniFileCredentials({profile: 'default'});
       }
 


### PR DESCRIPTION
add two needed parameters by calling method `JAWS._utils.setAwsAdminCreds` at line 75.

Closes https://github.com/jaws-stack/JAWS/issues/72