### PR TITLE
[V1][QUICK FIX] new subcommand

### DIFF
--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -249,8 +249,9 @@ function _createProjectDirectory() {
         path.join(project.rootPath, 'back', '.env'),
         'JAWS_STAGE=' + project.stage + '\nJAWS_DATA_MODEL_PREFIX=' + project.stage
     ),
-    fs.mkdirAsync(path.join(project.rootPath, 'front')),
-    fs.mkdirAsync(path.join(project.rootPath, 'tests')),
+    fs.mkdirSync(project.rootPath),
+    fs.mkdirSync(path.join(project.rootPath, 'front')),
+    fs.mkdirSync(path.join(project.rootPath, 'tests')),
     utils.writeFile(path.join(project.rootPath, 'admin.env'), adminEnv),
     utils.writeFile(path.join(project.rootPath, 'jaws-cf.json'), JSON.stringify(cfTemplate, null, 2)),
   ]);


### PR DESCRIPTION
This pull request introduces the following changes:

- create `project.rootPath` before making the subdirs in order to to fix the error `Error: ENOENT: no such file or directory, mkdir 'JAWS_PROJ/front']`
- Use `mkdirSync` instead of `mkdirAsync`