### PR TITLE
.env file needs contents, not its filepath

### DIFF
--- a/lib/commands/deploy_lambda.js
+++ b/lib/commands/deploy_lambda.js
@@ -432,13 +432,14 @@ Packager.prototype._packageNodeJs = Promise.method(function() {
 
           // Lambda freaks out if code doesnt end in newline
           var ocbWithNewline = optimizedCodeBuffer.concat(new Buffer('\n'));
+          var envData = fs.readFileSync(path.join(_this._distDir, 'back', '.env'));
 
           var handlerFileName = _this._lambdaJson.lambda.handler.split('.')[0],
               compressPaths = [
 
                 // handlerFileName is the full path lambda file including dir rel to back
                 {fileName: handlerFileName + '.js', data: ocbWithNewline},
-                {fileName: '.env', data: path.join(_this._distDir, 'back', '.env')},
+                {fileName: '.env', data: envData },
               ];
 
           if (_this._lambdaJson.lambda.package.optimize.includePaths.length) {

--- a/lib/templates/nodejs/handler.js
+++ b/lib/templates/nodejs/handler.js
@@ -2,10 +2,11 @@
 
 var path = require('path');
 
-require('dotenv').config({path: path.join('..', '..', '..', '.env'), silent: true});
+require('dotenv').config({path: path.join(eval('__dirname'), '..', '..', '..', '.env'), silent: true});
 
 module.exports.handler = function(event, context) {
   console.log('about to run..');
+  console.log('Environment: ' + process.env.JAWS_STAGE);
 
   context.done(null, {message: 'You\'ve made a successful request to your JAWS Lambda!'});
 };


### PR DESCRIPTION
On deployment the `.env` file had a filepath as its contents, not the actual environment variables.

`eval('dirname')` is required to get around browserify and find the correct place for `.env`