### PR TITLE
Dash fixes.

### DIFF
--- a/lib/commands/dash.js
+++ b/lib/commands/dash.js
@@ -71,20 +71,17 @@ CMD.prototype.run = Promise.method(function() {
                 _this._resources = selectedResources;
                 if (!_this._resources.length) {
                   return false;
-                } else {
-
-                  // TODO: Untag all other resources
-
-                  return _this._resources;
                 }
+                return _this._choices;
               })
               .each(function(resource) {
+                var toggled = (!!resource.toggled || false);
                 if (resource.type === 'lambda') {
                   _this._report.targetLambdas++;
-                  return CMDtag.tag('lambda', resource.value, false);
+                  return CMDtag.tag('lambda', resource.value, !toggled);
                 } else if (resource.type === 'endpoint') {
                   _this._report.targetEndpoints++;
-                  return CMDtag.tag('endpoint', resource.value, false);
+                  return CMDtag.tag('endpoint', resource.value, !toggled);
                 }
               });
         }
@@ -97,6 +94,9 @@ CMD.prototype.run = Promise.method(function() {
         JawsCli.log(chalk.white('-------------------------------------------'));
         JawsCli.log(chalk.white(' Dashboard:  Deploying Lambdas...'));
         JawsCli.log(chalk.white('-------------------------------------------'));
+        if (!_this._report.targetLambdas) {
+          return JawsCli.log(chalk.white('No Selected Lambdas to deploy.'));
+        }
 
         return CMDdeployLambda.run(
             _this._JAWS,
@@ -110,6 +110,9 @@ CMD.prototype.run = Promise.method(function() {
         JawsCli.log(chalk.white('-------------------------------------------'));
         JawsCli.log(chalk.white(' Dashboard:  Deploying Endpoints...'));
         JawsCli.log(chalk.white('-------------------------------------------'));
+        if (!_this._report.targetEndpoints) {
+          return JawsCli.log(chalk.white('No Selected Endpoints to deploy.'));
+        }
 
         return CMDdeployEndpoint.run(
             _this._JAWS,


### PR DESCRIPTION
Untag those not selected, tag those that are selected.
Return early if there are no endpoints to update or deploy.
Return early if there are no lambdas to update or deploy.