### PR TITLE
Env command improvements.

### DIFF
--- a/bin/jaws
+++ b/bin/jaws
@@ -195,6 +195,9 @@ program
 
       cmd = cmd.toLowerCase();
       switch (cmd) {
+        case 'test':
+          execute(CmdEnv.testEnv(JAWS, stage));
+          break;
         case 'list':
           execute(CmdEnv.listEnv(JAWS, stage));
           break;

--- a/lib/commands/env.js
+++ b/lib/commands/env.js
@@ -5,6 +5,7 @@
  */
 
 var JawsError = require('../jaws-error'),
+    JawsCli = require('../utils/cli'),
     Promise = require('bluebird'),
     utils = require('../utils'),
     fs = require('fs'),
@@ -71,6 +72,22 @@ module.exports.listEnv = function(JAWS, stage) {
         _this.getEnvFileAsMap(JAWS, stage),
       ])
       .spread(function(jawsJsonPaths, envMap) {
+        Object.keys(envMap).forEach(function(key) {
+          console.log(key + "=" + JSON.stringify(envMap[key]));
+        })
+
+        return envMap;
+      });
+};
+
+module.exports.testEnv = function(JAWS, stage) {
+  var _this = this;
+
+  return Promise.all([
+        utils.findAllJawsJsons(path.join(JAWS._meta.projectRootPath, 'back')),
+        _this.getEnvFileAsMap(JAWS, stage),
+      ])
+      .spread(function(jawsJsonPaths, envMap) {
         var envInBackMap = {};
 
         //first build up a list of all env vars modules say they need
@@ -87,20 +104,17 @@ module.exports.listEnv = function(JAWS, stage) {
           }
         });
 
-        console.log('ENV live in', stage, ':');
-        console.log(JSON.stringify(envMap, null, 2));
+        JawsCli.log_header(' ENV: ' + stage);
 
         var localEnvKeys = Object.keys(envInBackMap);
         if (localEnvKeys.length) {
-          console.log('\nWhere vars are used (' + chalk.yellow('yellow') + ' indicates not set in ' + stage + '):');
+          JawsCli.log('Where vars are used (' + chalk.red('red') + ' indicates not set in ' + stage + '):');
           localEnvKeys.forEach(function(key) {
-            var keyColored = (envMap[key]) ? key : chalk.yellow(key);
+            var keyColored = (envMap[key]) ? chalk.green(key) : chalk.red(key);
 
-            console.log(keyColored + ':', envInBackMap[key]);
+            JawsCli.log(keyColored + ': ' + chalk.white(envInBackMap[key].toString()));
           });
         }
-
-        console.log('\n');
 
         return envMap;
       });

--- a/lib/utils/cli.js
+++ b/lib/utils/cli.js
@@ -50,6 +50,12 @@ module.exports.log = function(message) {
   console.log('JAWS: ' + chalk.yellow(message + '  '));
 };
 
+module.exports.log_header = function(header) {
+  module.exports.log(chalk.white('-------------------------------------------'));
+  module.exports.log(chalk.white(' ' + header));
+  module.exports.log(chalk.white('-------------------------------------------'));
+};
+
 /**
  * Prompt
  */


### PR DESCRIPTION
Split out `list` and `test` for the `env` command.
This allows `list` to be used programatically: `jaws env list test > prod.env`.
`test` uses red for any missing ENV variables.
Added log_header export for all the ----\nheader\n----- goodness


<img width="426" alt="screen shot 2015-09-15 at 3 46 03 pm" src="https://cloud.githubusercontent.com/assets/27389/9868862/1884e15a-5bc1-11e5-92db-a9df9f6d0830.png">


Any tips on getting the test suite working locally? I imagine this could break some tests.