### PR TITLE
Run command

### DIFF
--- a/bin/jaws
+++ b/bin/jaws
@@ -87,6 +87,13 @@ program
       }
     });
 
+program
+    .command('run <stage>')
+    .description('Run the lambda in Stage <stage>')
+    .action(function(stage, options) {
+      var runner = require('../lib/commands/run');
+      execute(runner.run(JAWS, stage));
+    });
 /**
  * module
  * - install awsm

--- a/bin/jaws
+++ b/bin/jaws
@@ -87,6 +87,10 @@ program
       }
     });
 
+/**
+ * Run
+ * - Run a lambda locally
+ */
 program
     .command('run <stage>')
     .description('Run the lambda in Stage <stage>')

--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -5,12 +5,13 @@
  */
 
 var JawsError = require('../jaws-error'),
-    JawsCli = require('../utils/cli'),
-    JawsEnv = require('../commands/env'),
-    Promise = require('bluebird'),
-    utils = require('../utils'),
-    path = require('path'),
-    context = require('../utils/context');
+    JawsCli   = require('../utils/cli'),
+    JawsEnv   = require('../commands/env'),
+    Promise   = require('bluebird'),
+    utils     = require('../utils'),
+    path      = require('path'),
+    fs        = require('fs')
+    context   = require('../utils/context');
 
 var runHandler = function(handler, event, env) {
 
@@ -40,7 +41,12 @@ module.exports.run = function(JAWS, stage) {
   var envCmd = require('./env');
   return envCmd.getEnvFileAsMap(JAWS, stage).then(function(envMap) {
     var event     = require(process.cwd() + '/event.json');
-    var handler   = require(process.cwd() + '/handler.js');
+    var handler;
+    if (fs.existsSync(process.cwd() + '/handler.js')) {
+      handler = require(process.cwd() + '/handler.js');
+    } else {
+     handler = require(process.cwd() + '/index.js');
+    }
 
     runHandler(handler.handler, event, envMap);
   });

--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -1,0 +1,76 @@
+'use strict';
+
+/**
+ * JAWS Command: env
+ */
+
+var JawsError = require('../jaws-error'),
+    JawsCli = require('../utils/cli'),
+    JawsEnv = require('../commands/env'),
+    Promise = require('bluebird'),
+    utils = require('../utils'),
+    fs = require('fs'),
+    AWSUtils = require('../utils/aws'),
+    path = require('path'),
+    chalk = require('chalk'),
+    dotenv = require('dotenv');
+
+var runHandler = function(handler, event, env) {
+  var succeed = function(result) {
+    JawsCli.log('Lambda Finished Successfully: ');
+    JawsCli.log(JSON.stringify(result));
+    return process.exit(0);
+  }
+
+  var error = function(error) {
+    JawsCli.log(chalk.red('Lambda Returned An Error: '));
+    JawsCli.log(chalk.red(JSON.stringify(error)));
+    return process.exit(0);
+  }
+
+  var context = {
+    succeed: succeed,
+    error: error,
+    fail: error,
+    done: function(err, result) {
+      if (err) {
+        error(err)
+      }
+
+      if (result) {
+        succeed(result)
+      }
+
+      return process.exit(0);
+    }
+  };
+
+  var old_env = process.env;
+  try {
+    process.env = env;
+    handler(event, context);
+  } finally {
+    process.env = old_env;
+  }
+}
+
+/**
+ *
+ * @param {Jaws} JAWS
+ * @param stage
+ */
+
+module.exports.run = function(JAWS, stage) {
+  return Promise.all([
+      utils.findAllJawsJsons(path.join(JAWS._meta.projectRootPath, 'back')),
+      JawsEnv.getEnvFileAsMap(JAWS, stage),
+    ]).spread(function(jawsJsonPaths, envMap) {
+
+      JawsCli.log_header('Running tests in stage: ' + stage);
+
+      var extension = require(process.cwd() + '/index.js');
+      var event     = require(process.cwd() + '/event.json');
+
+      runHandler(extension.handler, event, envMap);
+    });
+}

--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -5,7 +5,7 @@
  */
 
 var JawsError = require('../jaws-error'),
-    JawsCli   = require('../utils/cli'),
+    JawsCLI   = require('../utils/cli'),
     JawsEnv   = require('../commands/env'),
     Promise   = require('bluebird'),
     utils     = require('../utils'),
@@ -20,10 +20,10 @@ var runHandler = function(handler, event, env) {
     process.env = env;
     handler(event, context(function(err, result) {
       if (err) {
-        console.log("Error: " + err);
+        JawsCLI.log("Error: " + err);
         return;
       }
-      console.log(result);
+      JawsCLI.log(JSON.stringify(result));
     }));
   } finally {
     process.env = old_env;

--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -10,7 +10,7 @@ var JawsError = require('../jaws-error'),
     Promise   = require('bluebird'),
     utils     = require('../utils'),
     path      = require('path'),
-    fs        = require('fs')
+    fs        = require('fs'),
     context   = require('../utils/context');
 
 var runHandler = function(handler, event, env) {

--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -9,38 +9,21 @@ var JawsError = require('../jaws-error'),
     JawsEnv = require('../commands/env'),
     Promise = require('bluebird'),
     utils = require('../utils'),
-    path = require('path')
+    path = require('path'),
+    context = require('../utils/context');
 
 var runHandler = function(handler, event, env) {
-  var succeed = function(result) {
-    return process.exit(0);
-  }
-
-  var error = function(error) {
-    return process.exit(0);
-  }
-
-  var context = {
-    succeed: succeed,
-    error: error,
-    fail: error,
-    done: function(err, result) {
-      if (err) {
-        error(err)
-      }
-
-      if (result) {
-        succeed(result)
-      }
-
-      return process.exit(0);
-    }
-  };
 
   var old_env = process.env;
   try {
     process.env = env;
-    handler(event, context);
+    handler(event, context(function(err, result) {
+      if (err) {
+        console.log("Error: " + err);
+        return;
+      }
+      console.log(result);
+    }));
   } finally {
     process.env = old_env;
   }
@@ -55,9 +38,7 @@ var runHandler = function(handler, event, env) {
 module.exports.run = function(JAWS, stage) {
 
   var envCmd = require('./env');
-  var envMap = envCmd.getEnvFileAsMap(JAWS, stage);
-
-  return new Promise(function() {
+  return envCmd.getEnvFileAsMap(JAWS, stage).then(function(envMap) {
     var event     = require(process.cwd() + '/event.json');
     var handler   = require(process.cwd() + '/handler.js');
 

--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
- * JAWS Command: env
+ * JAWS Command: run
  */
 
 var JawsError = require('../jaws-error'),
@@ -9,22 +9,14 @@ var JawsError = require('../jaws-error'),
     JawsEnv = require('../commands/env'),
     Promise = require('bluebird'),
     utils = require('../utils'),
-    fs = require('fs'),
-    AWSUtils = require('../utils/aws'),
-    path = require('path'),
-    chalk = require('chalk'),
-    dotenv = require('dotenv');
+    path = require('path')
 
 var runHandler = function(handler, event, env) {
   var succeed = function(result) {
-    JawsCli.log('Lambda Finished Successfully: ');
-    JawsCli.log(JSON.stringify(result));
     return process.exit(0);
   }
 
   var error = function(error) {
-    JawsCli.log(chalk.red('Lambda Returned An Error: '));
-    JawsCli.log(chalk.red(JSON.stringify(error)));
     return process.exit(0);
   }
 
@@ -61,16 +53,14 @@ var runHandler = function(handler, event, env) {
  */
 
 module.exports.run = function(JAWS, stage) {
-  return Promise.all([
-      utils.findAllJawsJsons(path.join(JAWS._meta.projectRootPath, 'back')),
-      JawsEnv.getEnvFileAsMap(JAWS, stage),
-    ]).spread(function(jawsJsonPaths, envMap) {
 
-      JawsCli.log_header('Running tests in stage: ' + stage);
+  var envCmd = require('./env');
+  var envMap = envCmd.getEnvFileAsMap(JAWS, stage);
 
-      var extension = require(process.cwd() + '/index.js');
-      var event     = require(process.cwd() + '/event.json');
+  return new Promise(function() {
+    var event     = require(process.cwd() + '/event.json');
+    var handler   = require(process.cwd() + '/handler.js');
 
-      runHandler(extension.handler, event, envMap);
-    });
+    runHandler(handler.handler, event, envMap);
+  });
 }

--- a/lib/utils/context.js
+++ b/lib/utils/context.js
@@ -1,0 +1,40 @@
+
+function guid() {
+  function s4() {
+    return Math.floor((1 + Math.random()) * 0x10000)
+      .toString(16)
+      .substring(1);
+  }
+  return s4() + s4() + '-' + s4() + '-' + s4() + '-' + s4() + '-' + s4() + s4() + s4();
+}
+
+module.exports = function(cb) {
+  cb = cb || function() {};
+
+  var id   = guid(),
+      name = 'test-lambda';
+
+  var succeed = function(result) { cb(null, result) };
+  var error   = function(error)  { cb(error, null) };
+
+  return {
+    awsRequestId:    id,
+    invokeid:        id,
+    logGroupName:    '/aws/lambda/' + name,
+    logStreamName:   '2015/09/22/[HEAD]13370a84ca4ed8b77c427af260',
+    functionVersion: 'HEAD',
+    isDefaultFunctionVersion: true,
+
+    functionName:    name,
+    memoryLimitInMB: '1024',
+    functionVersion: 'HEAD',
+
+    succeed:         succeed,
+    fail:            error,
+    done:            cb,
+
+    getRemainingTimeInMillis: function() {
+      return 5000;
+    }
+  }
+}

--- a/tests/cli/run.js
+++ b/tests/cli/run.js
@@ -1,0 +1,48 @@
+'use strict';
+
+/**
+ * JAWS Test: Run Command
+ */
+
+var Jaws = require('../../lib/index.js'),
+    CmdRun = require('../../lib/commands/run'),
+    testUtils = require('../test_utils'),
+    path = require('path'),
+    assert = require('chai').assert;
+
+var config = require('../config'),
+    projPath,
+    JAWS;
+
+describe('Test "run" command', function() {
+
+  before(function() {
+    projPath = testUtils.createTestProject(
+        config.name,
+        config.region,
+        config.stage,
+        config.iamRoleArnLambda,
+        config.iamRoleArnApiGateway,
+        config.regionBucket);
+    process.chdir(path.join(projPath, 'back', 'aws_modules', 'sessions', 'show'));
+    JAWS = new Jaws();
+  });
+
+  after(function(done) {
+    done();
+  });
+
+  describe('Positive tests', function() {
+    it('Test run command', function(done) {
+      this.timeout(0);
+
+      CmdRun.run(JAWS, config.stage)
+          .then(function(d) {
+            done();
+          })
+          .error(function(e) {
+            done(e);
+          });
+    });
+  });
+})

--- a/tests/test_utils.js
+++ b/tests/test_utils.js
@@ -44,6 +44,7 @@ module.exports.createTestProject = function(projectName,
   });
 
   // Create Cloudformation folders for stage/region and copy CF templates
+  fs.mkdirSync(path.join(tmpProjectPath, 'cloudformation'));
   fs.mkdirSync(path.join(tmpProjectPath, 'cloudformation', projectStage));
   fs.mkdirSync(path.join(tmpProjectPath, 'cloudformation', projectStage, projectRegion));
   var lambdasCF = require('../lib/templates/lambdas-cf.json');


### PR DESCRIPTION
## Problem
I needed a way to run the lambda locally with the correct environment variables, testing in AWS Lambda is difficult offline.


* [x] Run the handler in the environment, pulling from s3 bucket if required
* [x] tests 

```
[1] ~/w/b/b/l/h/get * ❯❯❯ jaws run local
JAWS: Error: {"id":"d073d50209e3","label":"Bobby","status":"fail"}
```

```
[1] ~/w/b/b/l/h/get * ❯❯❯ jaws run local
JAWS: {"id":"d073d50209e3","label":"Bobby","status":"ok"}
```

This does require a change in the #118 for `log_header` [here](https://github.com/jaws-framework/JAWS/pull/118/files#diff-945a66226d0012aff655853aecba7f83R53).