### PR TITLE
Store lambda role as iam... instead of Iam...

### DIFF
--- a/lib/commands/new_stage_region.js
+++ b/lib/commands/new_stage_region.js
@@ -215,7 +215,7 @@ CMD.prototype._updateProjectJson = Promise.method(function() {
 
   for (var i = 0; i < _this._cfData.Outputs.length; i++) {
     if (_this._cfData.Outputs[i].OutputKey === 'IamRoleArnLambda') {
-      regionObj.IamRoleArnLambda = _this._cfData.Outputs[i].OutputValue;
+      regionObj.iamRoleArnLambda = _this._cfData.Outputs[i].OutputValue;
     }
 
     if (_this._cfData.Outputs[i].OutputKey === 'IamRoleArnApiGateway') {


### PR DESCRIPTION
This is probably done away with the changes on the `cf-deploy` branch, but just in case some one else comes across this problem.

It manifests itself as `Role` being undefined when trying to deploy the lambda function to the new stage. You can fix it pretty easily by changing the capitalization within your `jaws.json` file.