### PR TITLE
Lambda name generation fix

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -212,7 +212,7 @@ module.exports.generateLambdaName = function(awsmJson) {
   var handlerName = awsmJson.lambda.cloudFormation.Handler.replace('aws_modules', ''),
       resourceAction = handlerName.substr(0, handlerName.lastIndexOf('/'));
 
-  return 'l' + resourceAction.replace(/\/([a-z])/g, function(g) {
+  return resourceAction.replace(/(\/|-|_)([a-z])/g, function(g) {
         return g[1].toUpperCase();
       });
 };


### PR DESCRIPTION
Remove additional l from the front of lambda name generation.
Sanitize extra dashses and underscores from lambda names
Closes #136