### PR TITLE
Don't show an error when loading admin.env...

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,12 @@ function Jaws() {
 
   if (_this._meta.projectRootPath) {
     _this._meta.projectJson = require(_this._meta.projectRootPath + '/jaws.json');
+
+    // Don't display dotenv load failures for admin.env if we already have the required
+    // environment variables.
+    var silent = !!process.env.ADMIN_AWS_PROFILE;
     require('dotenv').config({
+      silent: silent,
       path: path.join(_this._meta.projectRootPath, 'admin.env'),
     });
     _this._meta.profile = process.env.ADMIN_AWS_PROFILE;


### PR DESCRIPTION
Well, don't show an error if we already have the environment variables we need.

This is helpful in a CI server environment where you want to provide these values via actual environment variables.

I chose to continue reading `admin.env` even if the environment variable exists since the value in the file (if it exists) should probably take priority over existing environment variables.