### PR TITLE
Allow custom selectionPattern attributes

### DIFF
--- a/lib/commands/deploy_endpoint.js
+++ b/lib/commands/deploy_endpoint.js
@@ -793,13 +793,13 @@ ApiDeployer.prototype._createEndpointMethodIntegResponses = Promise.method(funct
         var integrationResponseBody = {};
 
         // Add Response Parameters
-        integrationResponseBody.responseParameters = thisResponse.responseParameters;
+        integrationResponseBody.responseParameters = thisResponse.responseParameters || {};
 
         // Add Response Templates
-        integrationResponseBody.responseTemplates = thisResponse.responseTemplates;
+        integrationResponseBody.responseTemplates = thisResponse.responseTemplates || {};
 
         // Add SelectionPattern
-        integrationResponseBody.selectionPattern = responseKey === 'default' ? null : responseKey;// null = default
+        integrationResponseBody.selectionPattern = thisResponse.selectionPattern || (responseKey === 'default' ? null : responseKey);
 
         // Create Integration Response
         return _this.ApiClient.putIntegrationResponse(


### PR DESCRIPTION
Especially when working with Lambda responses, you want to be able to configure custom selectionPatterns for responses. This was not supported. Also made some small improvements for optional config attributes.