### PR TITLE
Make Lambda permission stage-independent

### DIFF
--- a/lib/commands/deploy_endpoint.js
+++ b/lib/commands/deploy_endpoint.js
@@ -934,9 +934,7 @@ ApiDeployer.prototype._updateLambdaAccessPolicy = Promise.method(function(endpoi
       + _this._awsAccountNumber
       + ':'
       + _this._restApiId
-      + '/'
-      + _this._stage
-      + '/'
+      + '/*/'
       + endpoint.apiGateway.cloudFormation.Method
       + '/'
       + endpoint.apiGateway.cloudFormation.Path;


### PR DESCRIPTION
This fixes issue https://github.com/jaws-framework/JAWS/issues/156. As @rpgreen stated (https://github.com/awslabs/aws-apigateway-swagger-importer/issues/41#issuecomment-143066855), test invokes are not tied to a stage.