### PR TITLE
Tag all can now tag all endpoints and lambdas in one command

### DIFF
--- a/bin/jaws
+++ b/bin/jaws
@@ -163,18 +163,18 @@ program
 
 program
     .command('tag [type]')
-    .description('Tag lambda function or api gateway resource (endpoint) for deployment ' +
-        'the next time deploy command is run. Type "lambda" is the default.')
-    .option('-u, --untag', 'un-tag lambda|endpoint')
-    .option('-a, --tag-all', 'tag all lambda|endpoint functions in project')
-    .option('-l, --list-all', 'list all tagged lambda|endpoint functions in project')
-    .option('-n, --untag-all', 'un-tag all lambda|endpoint functions in project')
+    .description('Tag lambda function, api gateway resource (endpoint), or all of both for deployment ' +
+        'the next time deploy command is run. Type "all" is the default.')
+    .option('-u, --untag', 'un-tag lambda|endpoint|all')
+    .option('-a, --tag-all', 'tag all lambda|endpoint|all functions in project')
+    .option('-l, --list-all', 'list all tagged lambda|endpoint|all functions in project')
+    .option('-n, --untag-all', 'un-tag all lambda|endpoint|all functions in project')
     .action(function(type, options) {
-      type = type || 'lambda';
+      type = type || 'all';
       type = type.toLowerCase();
 
-      if (-1 == ['endpoint', 'lambda'].indexOf(type)) {
-        console.error('Unsupported type ' + type + '. Must be endpoint|lambda');
+      if (-1 == ['endpoint', 'lambda', 'all'].indexOf(type)) {
+        console.error('Unsupported type ' + type + '. Must be endpoint|lambda|all');
         process.exit(1);
       }
 

--- a/lib/commands/tag.js
+++ b/lib/commands/tag.js
@@ -29,10 +29,21 @@ module.exports.tag = function(type, fullPathToAwsmJson, untag) {
 
   return new Promise(function(resolve, reject) {
     if (!utils.fileExistsSync(awsmJsonPath)) {
-      reject(new JawsError('Could\'nt find a valid awsm.json. Sure you are in the correct directory?'));
+      reject(
+        new JawsError('Could\'nt find a valid awsm.json. Sure you are in the correct directory?'));
     }
 
-    if (type === 'lambda' && typeof awsmJson.lambda !== 'undefined') {
+    if (type === 'all') {
+
+      if (typeof awsmJson.lambda !== 'undefined') {
+        awsmJson.lambda.deploy = !untag;
+      }
+
+      if (typeof awsmJson.apiGateway !== 'undefined') {
+        awsmJson.apiGateway.deploy = !untag;
+      }
+
+    } else if (type === 'lambda' && typeof awsmJson.lambda !== 'undefined') {
       awsmJson.lambda.deploy = !untag;
     } else if (type === 'endpoint' && typeof awsmJson.apiGateway !== 'undefined') {
       awsmJson.apiGateway.deploy = !untag;
@@ -49,7 +60,7 @@ module.exports.tag = function(type, fullPathToAwsmJson, untag) {
  * Tag or untag all
  *
  * @param {Jaws} JAWS
- * @prams type endpoint|lambda
+ * @prams type endpoint|lambda|all
  * @param {boolean} untag default false
  * @returns {Promise}
  */
@@ -60,13 +71,17 @@ module.exports.tagAll = function(JAWS, type, untag) {
 
   return JAWS.validateProject()
       .then(function() {
-        return utils[findAllFunc](JAWS._meta.projectRootPath);
+        if (type === 'all') {
+          return utils.findAllAwsmJsons(JAWS._meta.projectRootPath);
+        } else {
+          return utils[findAllFunc](JAWS._meta.projectRootPath);
+        }
       })
       .then(function(awsmJsonPaths) {
         var tagQueue = [];
 
         if (!awsmJsonPaths) {
-          throw new JawsError('Could not find any lambdas', JawsError.errorCodes.UNKNOWN);
+          throw new JawsError('Could not find any lambdas or endpoints', JawsError.errorCodes.UNKNOWN);
         }
 
         awsmJsonPaths.forEach(function(awsmJsonPath) {

--- a/tests/cli/tag.js
+++ b/tests/cli/tag.js
@@ -99,5 +99,42 @@ describe('Test "tag" command', function() {
             done(e);
           });
     });
+
+    it('tag all', function(done) {
+      this.timeout(0);
+
+      CmdTag.tag('all', modulePaths.lambda1, false)
+          .then(function() {
+            assert.equal(true, require(modulePaths.lambda1).lambda.deploy);
+            assert.equal(true, require(modulePaths.lambda1).apiGateway.deploy);
+            assert.equal(false, require(modulePaths.lambda2).lambda.deploy);
+            assert.equal(false, require(modulePaths.lambda2).apiGateway.deploy);
+            assert.equal(false, require(modulePaths.lambda3).lambda.deploy);
+            assert.equal(false, require(modulePaths.lambda3).apiGateway.deploy);
+            return CmdTag.tagAll(JAWS, 'all', false);
+          })
+          .then(function() {
+            assert.equal(true, require(modulePaths.lambda1).lambda.deploy);
+            assert.equal(true, require(modulePaths.lambda1).apiGateway.deploy);
+            assert.equal(true, require(modulePaths.lambda2).lambda.deploy);
+            assert.equal(true, require(modulePaths.lambda2).apiGateway.deploy);
+            assert.equal(true, require(modulePaths.lambda3).lambda.deploy);
+            assert.equal(true, require(modulePaths.lambda3).apiGateway.deploy);
+            return CmdTag.tagAll(JAWS, 'all', true);
+          })
+          .then(function() {
+            assert.equal(false, require(modulePaths.lambda1).lambda.deploy);
+            assert.equal(false, require(modulePaths.lambda1).apiGateway.deploy);
+            assert.equal(false, require(modulePaths.lambda2).lambda.deploy);
+            assert.equal(false, require(modulePaths.lambda2).apiGateway.deploy);
+            assert.equal(false, require(modulePaths.lambda3).lambda.deploy);
+            assert.equal(false, require(modulePaths.lambda3).apiGateway.deploy);
+            done();
+          })
+          .error(function(e) {
+            done(e);
+          });
+    });
+
   });
 });


### PR DESCRIPTION
A proposed solution to jaws-framework/JAWS#164.

Implements a new “all” type which allows a user to tag all Lambdas and
Endpoints in one command. It also makes this the default command when
running a bare `jaws tag --tag-all` or `jaws tag --untag-all` with no
type option.