### PR TITLE
Explicit defining of tag type required, "all" is now "both"

### DIFF
--- a/bin/jaws
+++ b/bin/jaws
@@ -162,19 +162,18 @@ program
  */
 
 program
-    .command('tag [type]')
-    .description('Tag lambda function, api gateway resource (endpoint), or all of both for deployment ' +
-        'the next time deploy command is run. Type "all" is the default.')
-    .option('-u, --untag', 'un-tag lambda|endpoint|all')
-    .option('-a, --tag-all', 'tag all lambda|endpoint|all functions in project')
-    .option('-l, --list-all', 'list all tagged lambda|endpoint|all functions in project')
-    .option('-n, --untag-all', 'un-tag all lambda|endpoint|all functions in project')
+    .command('tag <type>')
+    .description('Tag lambda function, api gateway resource (endpoint), or both for deployment ' +
+        'the next time deploy command is run.')
+    .option('-u, --untag', 'un-tag lambda|endpoint|both')
+    .option('-a, --tag-all', 'tag all lambda|endpoint|both in project')
+    .option('-l, --list-all', 'list all tagged lambda|endpoint|both in project')
+    .option('-n, --untag-all', 'un-tag all lambda|endpoint|both in project')
     .action(function(type, options) {
-      type = type || 'all';
       type = type.toLowerCase();
 
-      if (-1 == ['endpoint', 'lambda', 'all'].indexOf(type)) {
-        console.error('Unsupported type ' + type + '. Must be endpoint|lambda|all');
+      if (-1 == ['endpoint', 'lambda', 'both'].indexOf(type)) {
+        console.error('Unsupported type ' + type + '. Must be endpoint|lambda|both');
         process.exit(1);
       }
 

--- a/lib/commands/tag.js
+++ b/lib/commands/tag.js
@@ -33,7 +33,7 @@ module.exports.tag = function(type, fullPathToAwsmJson, untag) {
         new JawsError('Could\'nt find a valid awsm.json. Sure you are in the correct directory?'));
     }
 
-    if (type === 'all') {
+    if (type === 'both') {
 
       if (typeof awsmJson.lambda !== 'undefined') {
         awsmJson.lambda.deploy = !untag;

--- a/tests/cli/tag.js
+++ b/tests/cli/tag.js
@@ -100,10 +100,10 @@ describe('Test "tag" command', function() {
           });
     });
 
-    it('tag all', function(done) {
+    it('tag both', function(done) {
       this.timeout(0);
 
-      CmdTag.tag('all', modulePaths.lambda1, false)
+      CmdTag.tag('both', modulePaths.lambda1, false)
           .then(function() {
             assert.equal(true, require(modulePaths.lambda1).lambda.deploy);
             assert.equal(true, require(modulePaths.lambda1).apiGateway.deploy);
@@ -111,7 +111,7 @@ describe('Test "tag" command', function() {
             assert.equal(false, require(modulePaths.lambda2).apiGateway.deploy);
             assert.equal(false, require(modulePaths.lambda3).lambda.deploy);
             assert.equal(false, require(modulePaths.lambda3).apiGateway.deploy);
-            return CmdTag.tagAll(JAWS, 'all', false);
+            return CmdTag.tagAll(JAWS, 'both', false);
           })
           .then(function() {
             assert.equal(true, require(modulePaths.lambda1).lambda.deploy);
@@ -120,7 +120,7 @@ describe('Test "tag" command', function() {
             assert.equal(true, require(modulePaths.lambda2).apiGateway.deploy);
             assert.equal(true, require(modulePaths.lambda3).lambda.deploy);
             assert.equal(true, require(modulePaths.lambda3).apiGateway.deploy);
-            return CmdTag.tagAll(JAWS, 'all', true);
+            return CmdTag.tagAll(JAWS, 'both', true);
           })
           .then(function() {
             assert.equal(false, require(modulePaths.lambda1).lambda.deploy);


### PR DESCRIPTION
As discussed in #164, explicitly defining the type is probably better. "all" is now switched in favor of "both".