### PR TITLE
Fix for "undefined" in help output

### DIFF
--- a/bin/jaws
+++ b/bin/jaws
@@ -288,10 +288,11 @@ program
       execute(CmdPostInstall.run(JAWS, moduleName, packageManager));
     });
 
+program.parse(process.argv);
+
 if (process.argv.length == 2) {
   program.outputHelp();
 } else {
-  program.parse(process.argv);
   if (program.verbose) {
     rawDebug.enable('jaws:*');
   }

--- a/lib/templates/nodejs/handler.js
+++ b/lib/templates/nodejs/handler.js
@@ -6,7 +6,7 @@
  * modules, to keep your code testable, reusable and AWS independent"
  */
 
-require('../../jaws-core-js/env');
+require('jaws-core-js/env');
 
 // Modularized Code
 var action = require('./index.js');


### PR DESCRIPTION
When invoking just `jaws` command, it was spitting out:
   Usage: undefined [options] [command]