### PR TITLE
Response models

### DIFF
--- a/examples/awsm.json
+++ b/examples/awsm.json
@@ -43,6 +43,7 @@
         "default": {
           "statusCode": "200",
           "responseParameters": {},
+          "responseModels": {},
           "responseTemplates": {
             "application/json": ""
           }

--- a/lib/commands/deploy_endpoint.js
+++ b/lib/commands/deploy_endpoint.js
@@ -398,8 +398,12 @@ ApiDeployer.prototype._findOrCreateApi = Promise.method(function() {
   } else {
 
     // Create REST API
+
+    var apiName = _this._prjJson.name + '-' + _this._stage;
+    apiName = apiName.substr( 0, 1023 ); // keep the name length below the limits
+
     return _this.ApiClient.createRestApi({
-      name: _this._prjJson.name,
+      name: apiName,
       description: _this._prjJson.description ? _this._prjJson.description : 'A REST API for a JAWS project.',
     }).then(function(response) {
 

--- a/lib/commands/deploy_endpoint.js
+++ b/lib/commands/deploy_endpoint.js
@@ -748,6 +748,18 @@ ApiDeployer.prototype._createEndpointMethodResponses = Promise.method(function(e
           }
         }
 
+        // If Request models, add them
+        if (thisResponse.responseModels) {
+
+          methodResponseBody.responseModels = {};
+
+          // Format Response Models per APIG API's Expectations
+          for (var name in thisResponse.responseModels) {
+            var value = thisResponse.responseModels[ name ];
+            methodResponseBody.responseModels[name] = value;
+          }
+        }
+
         // Create Method Response
         return _this.ApiClient.putMethodResponse(
             _this._restApiId,

--- a/lib/templates/action.awsm.json
+++ b/lib/templates/action.awsm.json
@@ -36,6 +36,7 @@
         "default": {
           "statusCode": "200",
           "responseParameters": {},
+          "responseModels": {},
           "responseTemplates": {
             "application/json": ""
           }

--- a/tests/test-prj/aws_modules/sessions/create/awsm.json
+++ b/tests/test-prj/aws_modules/sessions/create/awsm.json
@@ -48,6 +48,7 @@
         "default": {
           "statusCode": "200",
           "responseParameters": {},
+          "responseModels": {},
           "responseTemplates": {
             "application/json": ""
           }

--- a/tests/test-prj/aws_modules/sessions/show/awsm.json
+++ b/tests/test-prj/aws_modules/sessions/show/awsm.json
@@ -48,6 +48,7 @@
         "default": {
           "statusCode": "200",
           "responseParameters": {},
+          "responseModels": {},
           "responseTemplates": {
             "application/json": ""
           }


### PR DESCRIPTION
If you want to return custom Content-Type (like `text/html`) instead of `application/json` from lambda, you need to set method response models in API Gateway (among other things). This PR adds support for `responseModels: { "text/html": "Empty" }` which does the trick.