### PR TITLE
Fixed stage setting when stage prompt is used for `jaws deploy endpoint`

### DIFF
--- a/lib/commands/deploy_endpoint.js
+++ b/lib/commands/deploy_endpoint.js
@@ -143,7 +143,12 @@ CMD.prototype._promptStage = Promise.method(function() {
     });
   }
 
-  return JawsCli.select('Select a stage to deploy to: ', choices, false);
+  return JawsCli.select('Select a stage to deploy to: ', choices, false)
+    .then(function(selectedStages){
+      if( selectedStages && (selectedStages.length > 0) ) {
+        _this._stage = selectedStages[0].value;
+      }
+    });
 });
 
 /**


### PR DESCRIPTION
`jaws deploy endpoint` was crashing when stage was selected from prompt.