### PR TITLE
Fix postinstall to use `module.name` consistently.

### DIFF
--- a/lib/commands/postinstall.js
+++ b/lib/commands/postinstall.js
@@ -61,7 +61,7 @@ CMD.prototype.run = Promise.method(function() {
         return Promise.all([module, _this._saveCfTemplate(module.path)]);
       })
       .spread(function(module) {
-        var deferredDepInstalls = [];
+        var deferredDepInstalls = [module];
 
         switch (_this._packageManager) {
           case 'npm':
@@ -80,8 +80,8 @@ CMD.prototype.run = Promise.method(function() {
 
         return Promise.all(deferredDepInstalls);
       })
-      .then(function() {
-        return utils.findAllEnvVarsForAwsm(_this._JAWS._meta.projectRootPath, _this._moduleName);
+      .spread(function(module) {
+        return utils.findAllEnvVarsForAwsm(_this._JAWS._meta.projectRootPath, module.name);
       })
       .then(function(envVars) {
         JawsCLI.log('Successfully installed ' + _this._moduleName);


### PR DESCRIPTION
This fixes a bug where things would fail with an error like:

{ [Error: ENOENT: no such file or directory, lstat '.../aws_modules/awsm-cloudfront']
  errno: -2,
  code: 'ENOENT',
  syscall: 'lstat',
  path: '.../aws_modules/awsm-cloudfront' }

When the npm package name is different from the awsm package name.